### PR TITLE
build: compile with asio standalone

### DIFF
--- a/include/saf.hpp
+++ b/include/saf.hpp
@@ -876,7 +876,7 @@ class future
         if (!shared_state_)
             throw future_error{ future_errc::no_state };
 
-        return boost::asio::
+        return net::
             async_compose<CompletionToken, void(std::exception_ptr, T)>(
                 [shared_state = shared_state_,
                  init         = false](auto&& self, error_code ec = {}) mutable


### PR DESCRIPTION
The boost namespace slipped into the code so when using SAF_ASIO_STANDALONE the code does not compile.

This commit replaces the `boost::asio` namespace with the already existing alias `net`